### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   REGISTRY_USER: ${{ secrets.REGISTRY_USER }}
   IMAGE_REGISTRY: quay.io


### PR DESCRIPTION
Potential fix for [https://github.com/gopher64/gopher64-netplay-server/security/code-scanning/2](https://github.com/gopher64/gopher64-netplay-server/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, it primarily interacts with repository contents (e.g., checking out code) and does not require write access. Therefore, we will set `contents: read` as the default permission. If any job or step requires additional permissions, they can be added explicitly at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
